### PR TITLE
Update comments about removal of parking mins around transit

### DIFF
--- a/investigations/mbta_zoning_changes/mbta_zoning_calc.py
+++ b/investigations/mbta_zoning_changes/mbta_zoning_calc.py
@@ -113,8 +113,8 @@ class WalthamUnitCalc(QgsProcessingAlgorithm):
             )
         )
 
-        # optionally clobber any set parking mins
-        # near transit (Healey proposal)
+        # optionally remove any set parking mins
+        # near transit
         self.addParameter(
             QgsProcessingParameterBoolean(
                 self.RM_PARKING_NEAR_TRANSIT,

--- a/investigations/mbta_zoning_changes/notebook.ipynb
+++ b/investigations/mbta_zoning_changes/notebook.ipynb
@@ -366,7 +366,7 @@
     "\n",
     "1. Current as-built situation\n",
     "2. Current as-of-right situation\n",
-    "3. Current as-of-right + Gov. Healy's proposed removal of parking minimums around transit"
+    "3. Current as-of-right + removal of parking minimums around transit"
    ]
   },
   {


### PR DESCRIPTION
I still think it's useful to have the toggle in QGIS and comments in the notebook at least. It was a dramatic difference without parking when I was looking at the data.